### PR TITLE
fix readme instructions and makefile flag order

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,7 @@ LDFLAGS	:=$(LDFLAGS) -lm
 
 # Build the main executable
 $(OUT): $(OBJS)
-	$(CC) $(LDFLAGS) $^ -o $@
+	$(CC) $^ -o $@ $(LDFLAGS)
 
 # Remember that when this call is evaluated, it is expanded TWICE!
 define COMPILE

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ ekutils.
 ### How to test:
 Just run
 ```
-make utils && ./build/test
+make && ./build/test
 ```
 To test the utility library
 


### PR DESCRIPTION
## Previous Issues

The README says the following:

> Just run
>```
>make utils && ./build/test
>```
>To test the utility library

However this doesn't work:

```bash
$ make utils && ./test/build
make: *** No rule to make target 'utils'.  Stop.
```

Even using the default target will give the following:

```bash
$ make
mkdir -p build/src/
cc  -DEK_FEATURE_OFF=1 -O0 -g -std=gnu99 -c src/ek.c -o build/src/ek.o
mkdir -p build/src/test/
cc  -DEK_FEATURE_OFF=1 -O0 -g -std=gnu99 -c src/test/test.c -o build/src/test/test.o
cc  -lm build/src/ek.o build/src/test/test.o -o build/test
/usr/bin/ld: build/src/ek.o: in function `packet_write_float':
/home/ben256/ekutils/src/ek.c:779:(.text+0x2b45): undefined reference to `fmodf'
/usr/bin/ld: /home/ben256/ekutils/src/ek.c:786:(.text+0x2bf1): undefined reference to `fmodf'
collect2: error: ld returned 1 exit status
make: *** [Makefile:17: build/test] Error 1
```

(on Linux x86_64 with gcc)

## Fixes

- update readme to use valid default target
- update markdown compilation to put flags in an order that gcc likes more